### PR TITLE
fix-event-handler

### DIFF
--- a/jstypograph.js
+++ b/jstypograph.js
@@ -526,6 +526,9 @@
             }
         };
 		
+		// Привязывает метод typography к объекту (для корректной работы в обработчиках событий)
+        this.typography = this.typography.bind(this);
+		
 		// Привязывает кнопку для запуска типографа. Накладывает this.typography на onclick
         this.addButton = function(button) {
             addEvent(button, 'click', this.typography);


### PR DESCRIPTION
Для корректной работы типографа, запущенного по нажатию на кнопку, ранее добавленную методом `addButton`, необходимо привязать метод `typography` к объекту типографа. Иначе метод `typography` обращаясь к `this` будет получать объект DOM на котором сработало событие `click`.